### PR TITLE
Improve performance on longer markdown strings

### DIFF
--- a/Markr.xcodeproj/project.pbxproj
+++ b/Markr.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A1E657AE1F8D88FE009B2768 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E657AD1F8D88FE009B2768 /* PreferencesViewController.swift */; };
 		A1E657B01F8D891C009B2768 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E657AF1F8D891C009B2768 /* PreferencesWindowController.swift */; };
 		CA63136207729E358D935359 /* Pods_markr.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30CB73E6CA5A7AE5F9603168 /* Pods_markr.framework */; };
+		D85814F0204E65C9007ED0B3 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85814EF204E65C9007ED0B3 /* Debouncer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		A1DA46281FA0516900D4C565 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		A1E657AD1F8D88FE009B2768 /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		A1E657AF1F8D891C009B2768 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
+		D85814EF204E65C9007ED0B3 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 				A1B5F19D1F9182AB0000B40D /* MarkdownFormatter.swift */,
 				A11CF92B1F8B4E2E002BD372 /* EditorViewController.swift */,
 				A11CF9241F8B4D83002BD372 /* Info.plist */,
+				D85814EF204E65C9007ED0B3 /* Debouncer.swift */,
 			);
 			path = Markr;
 			sourceTree = "<group>";
@@ -235,6 +238,7 @@
 			files = (
 				A11CF92E1F8B4E52002BD372 /* MarkdownViewController.swift in Sources */,
 				A11CF92C1F8B4E2E002BD372 /* EditorViewController.swift in Sources */,
+				D85814F0204E65C9007ED0B3 /* Debouncer.swift in Sources */,
 				A1E657B01F8D891C009B2768 /* PreferencesWindowController.swift in Sources */,
 				A11CF91C1F8B4D83002BD372 /* AppDelegate.swift in Sources */,
 				A1E657AE1F8D88FE009B2768 /* PreferencesViewController.swift in Sources */,

--- a/Markr/Debouncer.swift
+++ b/Markr/Debouncer.swift
@@ -1,0 +1,32 @@
+//
+//  Debouncer.swift
+//  Markr
+//
+//  Created by Sahand on 3/5/18.
+//  Adapted for this project, originally from github.com/webadnan/swift-debouncer.
+//  Copyright © 2018 Luka Kerr. All rights reserved.
+//
+
+import Foundation
+
+class Debouncer: NSObject {
+    var callback: (() -> ())
+    var delay: Double
+    weak var timer: Timer?
+    
+    init(delay: Double, callback: @escaping (() -> ())) {
+        self.delay = delay
+        self.callback = callback
+    }
+    
+    func call() {
+        timer?.invalidate()
+        let nextTimer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(fireNow), userInfo: nil, repeats: false)
+        timer = nextTimer
+    }
+    
+    @objc func fireNow() {
+        self.callback()
+    }
+}
+

--- a/Markr/MarkdownViewController.swift
+++ b/Markr/MarkdownViewController.swift
@@ -53,6 +53,7 @@ class MarkdownViewController: NSViewController {
     let formattedMarkdown = MarkdownFormatter().format(markdownString)
     markdown.textStorage?.mutableString.setString("")
     markdown.textStorage?.append(formattedMarkdown)
+    markdown.textStorage?.endEditing()
     setWordCountLabel()
   }
   


### PR DESCRIPTION
Hey @lukakerr, this is awesome. I was just playing with it and noticed that with really long amounts of text, the app starts to hang on every key press. There are a few ways to handle this, and maybe you'd rather handle it another way, totally cool, but I thought I'd contribute what I could think of.

This PR does a few things —

1. Moves the `toAttributedString()` call onto a background thread
2. Uses available functions on `NSTextStorage`, `beginEditing` and `endEditing`, to signal to the `NSTextView` when the text replacement is going to happen and has happened to help the view automatically batch the updates
3. Adds a debouncer ([more on this](http://drupalmotion.com/article/debounce-and-throttle-visual-explanation) if you'd like)

This is the sample text I was using to compare the difference that I found after a search for "long markdown": https://github.com/toptensoftware/markdowndeep/blob/master/Backup/MarkdownDeepBenchmark/benchmark/markdown-example-long-2.text

Hope this helps!